### PR TITLE
Add more fields to RunLevel and DeadProcess

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -13,10 +13,12 @@ pub enum UtmpEntry {
     Empty,
     /// Change in system run-level (see `init(8)`)
     RunLevel {
+        pid: pid_t,
         /// Kernel version
         kernel_version: String,
         /// Time entry was made
         time: DateTime<Utc>,
+        user: String,
     },
     /// Time of system boot
     BootTime(DateTime<Utc>),
@@ -72,8 +74,10 @@ impl<'a> TryFrom<&'a utmp> for UtmpEntry {
         Ok(match from.ut_type {
             utmp_raw::EMPTY => UtmpEntry::Empty,
             utmp_raw::RUN_LVL => UtmpEntry::RunLevel {
+                pid: from.ut_pid,
                 kernel_version: string_from_bytes(&from.ut_host).map_err(UtmpError::InvalidHost)?,
                 time: time_from_tv(from.ut_tv)?,
+                user: string_from_bytes(&from.ut_user).map_err(UtmpError::InvalidUser)?,
             },
             utmp_raw::BOOT_TIME => UtmpEntry::BootTime(time_from_tv(from.ut_tv)?),
             utmp_raw::NEW_TIME => UtmpEntry::NewTime(time_from_tv(from.ut_tv)?),


### PR DESCRIPTION
I found that it can be useful to have `line` and `time` fields in `DeadProcess` and `pid` and `user` fields in `RunLevel`. For example, I am trying to make a rust version of `last.c` (more as a library than a serious command line replacement of `last`), and these fields are all required.